### PR TITLE
Replace Daudix's Linktree with GitHub link

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -335,7 +335,7 @@ class AdwcustomizerApplication(Adw.Application):
                                 application_icon='com.github.ArtyIF.AdwCustomizer',
                                 developer_name=_("Adwaita Manager Team"),
                                 developers=['Artyom "ArtyIF" Fomin https://github.com/ArtyIF', 'Verantor https://github.com/Verantor'],
-                                artists=['David "Daudix UFO" Lapshin https://linktr.ee/daudix_ufo'],
+                                artists=['David "Daudix UFO" Lapshin https://github.com/daudix-UFO'],
                                 translator_credits=_("translator-credits"),
                                 copyright='© 2022 Adwaita Manager Team',
                                 license_type=Gtk.License.MIT_X11)


### PR DESCRIPTION
I think that some people will not like to use that service by default (privacy reasons), if someone want to see my linktree, it can be done from GitHub